### PR TITLE
크롤링 중복 이미지 디버깅

### DIFF
--- a/src/main/java/com/example/bucketplace/domain/product/scheduler/ProductScheduler.java
+++ b/src/main/java/com/example/bucketplace/domain/product/scheduler/ProductScheduler.java
@@ -57,9 +57,9 @@ public class ProductScheduler {
     private List<Product> crawlProducts(WebDriver webDriver) throws InterruptedException {
         List<Product> productList = new ArrayList<>();
         JavascriptExecutor javascriptExecutor = (JavascriptExecutor) webDriver;
-        WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(5));
+        WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(20));
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 3; i++) {
             javascriptExecutor.executeScript("window.scrollBy(0, 5000)");
             Thread.sleep(3000);
 
@@ -91,7 +91,7 @@ public class ProductScheduler {
         boolean isFreeDelivery = safelyFindElement(webElement, By.xpath("//*[@aria-label='무료배송']")).isPresent();
         boolean isSpecialPrice = safelyFindElement(webElement, By.xpath("//*[@aria-label='특가']")).isPresent();
 
-        WebElement imageElement = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".image")));
+        WebElement imageElement = wait.until(ExpectedConditions.visibilityOf(webElement.findElement(By.cssSelector(".image"))));
         String imageUrl = imageElement.getAttribute("src");
 
         return Product.builder()


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->
<!-- 기입 예 -->
<!-- * #{이슈번호} -->

* #55 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* explicit wait 메서드 변경
* timeout error 방지 위해 한 번에 로드되는 스크롤 범위 축소(5 -> 3)
* explicit wait 대기 시간 확대 (5 -> 20초)

## Check List

<!-- 기능 구현을 다 했다면? -->

- [X] 포스트맨으로 체크해 보았나요?
![image](https://github.com/openmpy/bucketplace-clone/assets/149031461/1f68c029-c113-44b4-803b-0a2b4d7d5063)

## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요 -->
<!-- 다음은 예시입니다. 자유롭게 기록해 주세요. -->

* 다른 컬럼과 달리 imageUrl만 중복되어 크롤링

문제가 발생한 코드

```java
// 코드
WebElement imageElement = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".image")));
```

원인 분석

> explicit wait 메서드가 첫번째 것만 선택하는 것이었다.

수정한 코드

```java
// 수정한 코드
WebElement imageElement = wait.until(ExpectedConditions.visibilityOf(webElement.findElement(By.cssSelector(".image"))));
```